### PR TITLE
fix: Only Vigad.ts has access to StreamHandler instance

### DIFF
--- a/src/components/MainVideoStream.vue
+++ b/src/components/MainVideoStream.vue
@@ -20,10 +20,13 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue';
 import { useMouseInElement, useElementSize } from '@vueuse/core';
-import { StreamHandler } from '@/proc/StreamHandler';
+import { Vigad } from '@/proc/Vigad';
 
-// Get singelton instance of streamHandler
-const streamHandler = StreamHandler.getInstance();
+// Get singelton instance reference to vigad
+const vigad = Vigad.getInstance();
+
+// Get singelton instance reference to streamHandler
+const streamHandler = vigad.getStreamHandlerInstance();
 
 // Mouse position relative to the element and is in and out
 const mainVideo = ref<HTMLVideoElement | null>(null);

--- a/src/proc/Vigad.ts
+++ b/src/proc/Vigad.ts
@@ -12,7 +12,7 @@ export class Vigad {
     }
 
     /**
-     * This function gets the singelton instance of the StreamHandler
+     * This function gets the singelton instance of Vigad.ts
      *
      * @returns the singelton instance of the StreamHandler
      */

--- a/src/proc/Vigad.ts
+++ b/src/proc/Vigad.ts
@@ -14,7 +14,7 @@ export class Vigad {
     /**
      * This function gets the singelton instance of Vigad.ts
      *
-     * @returns the singelton instance of the StreamHandler
+     * @return Vigad
      */
     public static getInstance(): Vigad {
         if (!this.instance) {

--- a/src/proc/Vigad.ts
+++ b/src/proc/Vigad.ts
@@ -1,5 +1,30 @@
-class Vigad {
-    public main() {
-        // ...
+import { StreamHandler } from './StreamHandler';
+
+export class Vigad {
+    private static instance: Vigad;
+    private streamHandler: StreamHandler;
+
+    /**
+     * Create a private constructor to prevent multiple instances
+     */
+    private constructor() {
+        this.streamHandler = StreamHandler.getInstance();
+    }
+
+    /**
+     * This function gets the singelton instance of the StreamHandler
+     *
+     * @returns the singelton instance of the StreamHandler
+     */
+    public static getInstance(): Vigad {
+        if (!this.instance) {
+            this.instance = new this();
+        }
+
+        return this.instance;
+    }
+
+    public getStreamHandlerInstance(): StreamHandler {
+        return this.streamHandler;
     }
 }

--- a/src/views/SourcesView.vue
+++ b/src/views/SourcesView.vue
@@ -41,10 +41,13 @@
 <script setup lang="ts">
 import ViewComponent from '@/components/ViewComponent.vue';
 import { ref, computed, onMounted } from 'vue';
-import { StreamHandler } from '@/proc/StreamHandler';
+import { Vigad } from '@/proc/Vigad';
 
-// Get singelton instance of DesktopVideoStream
-const streamHandler = StreamHandler.getInstance();
+// Get singelton instance reference to vigad
+const vigad = Vigad.getInstance();
+
+// Get singelton instance reference to streamHandler
+const streamHandler = vigad.getStreamHandlerInstance();
 
 // For the Screen / Application Tab
 const tab = ref(null);


### PR DESCRIPTION
Signed-off-by: Kevin Beier <beierkevin2002@outlook.com>

# PR description
*Describe your changes in detail here*

A cleaner way to separate our backend from the frontend. That only the Vigad Singelton knows the instance of the StreamHandler and that where we get access to it.

# Definition Of Done (DoD)
*This PR can be squashed / merged if*
- [x] a developer is assigned
- [x] the PR is NOT estimated
- [x] the PR is labeled
- [x] the PR is assigned to the current sprint
- [x] a meaningful title has been set according to https://www.conventionalcommits.org/
- [x] the PR is described in detail
- [x] the PR links to an issue
- [x] the PR has been reviewed

*Add additional conditions here if necessary for this PR*

fix: #46 