### PR TITLE
feat(chore): add move to next sprint workflow

### DIFF
--- a/.github/workflows/next-iteration.yml
+++ b/.github/workflows/next-iteration.yml
@@ -1,0 +1,20 @@
+on:
+  schedule:
+    # Runs "at 12:00, only on Thursday"
+    - cron: '0 12 * * 4'
+
+jobs:
+  move-to-next-iteration:
+    name: Move to next iteration
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: blombard/move-to-next-iteration@master
+      with:
+        owner: VIGAD
+        number: 1
+        token: ${{ secrets.PROJECT_PAT }}
+        iteration-field: Sprint
+        iteration: last
+        new-iteration: current
+        statuses: Not Ready,In Progress,Ready for review


### PR DESCRIPTION
# PR description
*Describe your changes in detail here*
This adds a workflow that will automatically move items on the project board to the next sprint when overdue (runs at 12:00 on Thursday).

# Definition Of Done (DoD)
*This PR can be squashed / merged if*
- [x] a developer is assigned
- [x] the PR is NOT estimated
- [x] the PR is labeled
- [x] the PR is assigned to the current sprint
- [x] a meaningful title has been set according to https://www.conventionalcommits.org/
- [x] the PR is described in detail
- [x] the PR links to an issue
- [x] the PR has been reviewed

*Add additional conditions here if necessary for this PR*
