### PR TITLE
fix(capturing): added alerts and disabled start button

### DIFF
--- a/src/views/RegexView.vue
+++ b/src/views/RegexView.vue
@@ -10,7 +10,7 @@
             >
         </template>
         <template v-slot:default>
-            <v-expansion-panels multiple>
+            <v-expansion-panels v-if="captureAreas.length !== 0" multiple>
                 <v-expansion-panel
                     v-if="isRerendering"
                     v-for="captureArea in captureAreas"
@@ -30,6 +30,13 @@
                     </v-expansion-panel-text>
                 </v-expansion-panel>
             </v-expansion-panels>
+            <v-alert
+                v-else
+                type="info"
+                variant="tonal"
+                prominent
+                text="In order to locate a value within the stream, you must create a capture area."
+            ></v-alert>
         </template>
     </ViewComponent>
 </template>

--- a/src/views/RunPage.vue
+++ b/src/views/RunPage.vue
@@ -6,6 +6,7 @@
                 class="rounded-pill"
                 prepend-icon="mdi-play"
                 variant="tonal"
+                :disabled="captureAreas.length === 0"
                 @click="useRunning().start()"
                 >Start</v-btn
             >
@@ -21,10 +22,18 @@
         <template v-slot:default>
             <v-expansion-panels v-model="defaultOpenPanel" multiple>
                 <LogOutput
+                    v-if="captureAreas.length !== 0"
                     v-for="captureArea in captureAreas"
                     :key="captureArea.getId()"
                     :captureAreaId="captureArea.getId()"
                 />
+                <v-alert
+                    v-else
+                    type="info"
+                    variant="tonal"
+                    prominent
+                    text="To commence capturing, you must first define at least one capture area."
+                ></v-alert>
             </v-expansion-panels>
         </template>
     </ViewComponent>


### PR DESCRIPTION
# PR description
*Describe your changes in detail here*

I have added an alert info on both the capturing and regex panel to notify the user that they need to first or in general have to create a capture area to start capturing. The start capturing button is disabled if no capture area exists.

# Definition Of Done (DoD)
*This PR can be squashed / merged if*
- [x] a developer is assigned
- [x] the PR is NOT estimated
- [x] the PR is labeled
- [x] the PR is NOT assigned to the current sprint
- [x] a meaningful title has been set according to https://www.conventionalcommits.org/
- [x] the PR is described in detail
- [x] the PR links to an issue
- [x] the PR has been reviewed

*Add additional conditions here if necessary for this PR*

Fix: #96 