### PR TITLE
refactor: cleaned up old composables to follow proper conventions

### DIFF
--- a/src/components/LogOutput/LogOutput.vue
+++ b/src/components/LogOutput/LogOutput.vue
@@ -9,15 +9,11 @@
             <v-list v-else lines="three" disabled class="reverse">
                 <v-list-item v-for="(item, i) in matchedElements" :key="i">
                     <template v-slot:prepend>
-                        <v-icon
-                            :color="item.rating > 0 ? 'success' : 'error'"
-                            icon="mdi-information"
-                        ></v-icon>
+                        <v-icon :color="item.rating > 0 ? 'success' : 'error'" icon="mdi-information"></v-icon>
                     </template>
 
                     <v-list-item-title expand-icon="mdi-menu-down">
-                        {{ item.timestamp }}</v-list-item-title
-                    >
+                        {{ item.timestamp }}</v-list-item-title>
                     <div>Element: {{ item.match.element }}</div>
                     <div>Rating: {{ item.rating }}</div>
                 </v-list-item>
@@ -29,11 +25,14 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
 import { Vigad } from '@/proc/Vigad';
-import { isRunning } from '@/composables/useRunning/useRunning';
+import useRunning from '@/composables/useRunning/useRunning';
 
 const props = defineProps<{
     captureAreaId: number;
 }>();
+
+// Use the useRunning composable to get the isRunning state and the start/stop functions
+const { isRunning } = useRunning();
 
 /**
  * Get singelton instance reference to vigad
@@ -90,6 +89,7 @@ watch(isRunning, (newValue) => {
     max-height: 400px;
     overflow-y: auto;
 }
+
 .reverse {
     display: flex;
     flex-direction: column-reverse;

--- a/src/components/LogOutput/LogOutput.vue
+++ b/src/components/LogOutput/LogOutput.vue
@@ -9,11 +9,15 @@
             <v-list v-else lines="three" disabled class="reverse">
                 <v-list-item v-for="(item, i) in matchedElements" :key="i">
                     <template v-slot:prepend>
-                        <v-icon :color="item.rating > 0 ? 'success' : 'error'" icon="mdi-information"></v-icon>
+                        <v-icon
+                            :color="item.rating > 0 ? 'success' : 'error'"
+                            icon="mdi-information"
+                        ></v-icon>
                     </template>
 
                     <v-list-item-title expand-icon="mdi-menu-down">
-                        {{ item.timestamp }}</v-list-item-title>
+                        {{ item.timestamp }}</v-list-item-title
+                    >
                     <div>Element: {{ item.match.element }}</div>
                     <div>Rating: {{ item.rating }}</div>
                 </v-list-item>

--- a/src/components/MainVideoStream/MainVideoStream.vue
+++ b/src/components/MainVideoStream/MainVideoStream.vue
@@ -42,8 +42,13 @@ import { useElementSize } from '@vueuse/core';
 import { Vigad } from '@/proc/Vigad';
 // @ts-ignore
 import VueDragResize from 'vue3-drag-resize';
-import { isRerendering } from '@/composables/useForceRerender/useForceRerender';
+import useForceRerender from '@/composables/useForceRerender/useForceRerender';
 import { Rectangle } from './Rectangle';
+
+/**
+ * Use the useForceRerender composable to get the isRerendering state and the forceRerender functions
+ */
+const { isRerendering } = useForceRerender();
 
 /**
  * Get singelton instance reference to vigad

--- a/src/components/Navigation/Navigation.vue
+++ b/src/components/Navigation/Navigation.vue
@@ -1,14 +1,29 @@
 <template>
     <v-bottom-navigation :elevation="24" bg-color="surface" grow>
-        <v-btn :disabled="isRunning" to="/capture" prepend-icon="mdi-play" value="run">
+        <v-btn
+            :disabled="isRunning"
+            to="/capture"
+            prepend-icon="mdi-play"
+            value="run"
+        >
             Capturing
         </v-btn>
 
-        <v-btn :disabled="isRunning" to="/" prepend-icon="mdi-monitor" value="source">
+        <v-btn
+            :disabled="isRunning"
+            to="/"
+            prepend-icon="mdi-monitor"
+            value="source"
+        >
             Source
         </v-btn>
 
-        <v-btn :disabled="isRunning" to="/regex" prepend-icon="mdi-regex" value="regex">
+        <v-btn
+            :disabled="isRunning"
+            to="/regex"
+            prepend-icon="mdi-regex"
+            value="regex"
+        >
             Regex
         </v-btn>
 

--- a/src/components/Navigation/Navigation.vue
+++ b/src/components/Navigation/Navigation.vue
@@ -1,29 +1,14 @@
 <template>
     <v-bottom-navigation :elevation="24" bg-color="surface" grow>
-        <v-btn
-            :disabled="isRunning"
-            to="/capture"
-            prepend-icon="mdi-play"
-            value="run"
-        >
+        <v-btn :disabled="isRunning" to="/capture" prepend-icon="mdi-play" value="run">
             Capturing
         </v-btn>
 
-        <v-btn
-            :disabled="isRunning"
-            to="/"
-            prepend-icon="mdi-monitor"
-            value="source"
-        >
+        <v-btn :disabled="isRunning" to="/" prepend-icon="mdi-monitor" value="source">
             Source
         </v-btn>
 
-        <v-btn
-            :disabled="isRunning"
-            to="/regex"
-            prepend-icon="mdi-regex"
-            value="regex"
-        >
+        <v-btn :disabled="isRunning" to="/regex" prepend-icon="mdi-regex" value="regex">
             Regex
         </v-btn>
 
@@ -32,8 +17,11 @@
 </template>
 
 <script setup lang="ts">
-import { isRunning } from '@/composables/useRunning/useRunning';
+import useRunning from '@/composables/useRunning/useRunning';
 import SettingsPrompt from '@/components/SettingsPrompt/SettingsPrompt.vue';
+
+// Use the useRunning composable to get the isRunning state
+const { isRunning } = useRunning();
 </script>
 
 <style lang="scss" scoped></style>

--- a/src/composables/useForceRerender/useForceRerender.test.ts
+++ b/src/composables/useForceRerender/useForceRerender.test.ts
@@ -1,12 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
-import {
-    useForceRerender,
-    isRerendering,
-} from '@/composables/useForceRerender/useForceRerender';
+import useForceRerender from '@/composables/useForceRerender/useForceRerender';
 
 describe('useForceRerender Composable', () => {
     it('should trigger a rerender when called', async () => {
+        const { isRerendering, forceRerender } = useForceRerender();
+
         const text = 'Component to rerender';
 
         const wrapper = mount({
@@ -23,7 +22,7 @@ describe('useForceRerender Composable', () => {
         });
 
         // Call the useForceRerender composable
-        await useForceRerender();
+        await forceRerender();
 
         // Check that the component has rerendered
         expect(wrapper.text()).toBe(text);

--- a/src/composables/useForceRerender/useForceRerender.ts
+++ b/src/composables/useForceRerender/useForceRerender.ts
@@ -3,20 +3,27 @@ import { nextTick, ref } from 'vue';
 /**
  * Reactive boolean that can be used to force a component to rerender.
  */
-export const isRerendering = ref(true);
+const isRerendering = ref(true);
 
 /**
  * Tries to rerender the component by removing it from the DOM and adding it back in.
  *
- * Only works if the compnent has a v-if="rerender" directive. active
+ * Only works if the component has a v-if="rerender" directive.
  */
-export const useForceRerender = async () => {
-    // Remove component from the DOM
-    isRerendering.value = false;
+export default function useForceRerender() {
+    const forceRerender = async () => {
+        // Remove component from the DOM
+        isRerendering.value = false;
 
-    // Wait for the change to get flushed to the DOM
-    await nextTick();
+        // Wait for the change to get flushed to the DOM
+        await nextTick();
 
-    // Add the component back in
-    isRerendering.value = true;
-};
+        // Add the component back in
+        isRerendering.value = true;
+    };
+
+    return {
+        forceRerender,
+        isRerendering,
+    };
+}

--- a/src/composables/useRunning/useRunning.ts
+++ b/src/composables/useRunning/useRunning.ts
@@ -5,15 +5,18 @@ import useNotificationSystem from '@/composables/useNotificationSystem/useNotifi
 /**
  * Reactive boolean that can be used to check the capture status.
  */
-export const isRunning = ref(false);
+const isRunning = ref(false);
 
 /**
  * Function that can be used to start and stop the capturing.
  */
-export const useRunning = () => {
+export default function useRunning() {
     const vigad = Vigad.getInstance();
 
-    const start = () => {
+    /**
+     * Start capturing.
+     */
+    const start = (): void => {
         isRunning.value = true;
         vigad.startTesseract();
         useNotificationSystem().createNotification({
@@ -22,13 +25,16 @@ export const useRunning = () => {
         });
     };
 
-    const stop = () => {
+    /**
+     * Stop capturing.
+     */
+    const stop = (): void => {
         isRunning.value = false;
         vigad.stopTesseract();
         useNotificationSystem().createWarningNotification({
             title: 'Stopped Capturing',
             message: 'Capturing was stopped'
-        })
+        });
     };
 
     return {
@@ -36,4 +42,4 @@ export const useRunning = () => {
         start,
         stop,
     };
-};
+}

--- a/src/composables/useRunning/useRunning.ts
+++ b/src/composables/useRunning/useRunning.ts
@@ -21,7 +21,7 @@ export default function useRunning() {
         vigad.startTesseract();
         useNotificationSystem().createNotification({
             title: 'Started Capturing',
-            message: 'Capturing is now running'
+            message: 'Capturing is now running',
         });
     };
 
@@ -33,7 +33,7 @@ export default function useRunning() {
         vigad.stopTesseract();
         useNotificationSystem().createWarningNotification({
             title: 'Stopped Capturing',
-            message: 'Capturing was stopped'
+            message: 'Capturing was stopped',
         });
     };
 

--- a/src/views/CapturePage.vue
+++ b/src/views/CapturePage.vue
@@ -1,39 +1,16 @@
 <template>
     <ViewComponent title="Capturing" :loading="isRunning">
         <template v-slot:actions>
-            <v-btn
-                v-if="!isRunning"
-                class="rounded-pill"
-                prepend-icon="mdi-play"
-                variant="tonal"
-                :disabled="captureAreas.length === 0"
-                @click="useRunning().start()"
-                >Start</v-btn
-            >
-            <v-btn
-                v-else
-                class="rounded-pill"
-                prepend-icon="mdi-stop"
-                variant="tonal"
-                @click="useRunning().stop()"
-                >Stop</v-btn
-            >
+            <v-btn v-if="!isRunning" class="rounded-pill" prepend-icon="mdi-play" variant="tonal"
+                :disabled="captureAreas.length === 0" @click="start()">Start</v-btn>
+            <v-btn v-else class="rounded-pill" prepend-icon="mdi-stop" variant="tonal" @click="stop()">Stop</v-btn>
         </template>
         <template v-slot:default>
             <v-expansion-panels v-model="defaultOpenPanel" multiple>
-                <LogOutput
-                    v-if="captureAreas.length !== 0"
-                    v-for="captureArea in captureAreas"
-                    :key="captureArea.getId()"
-                    :captureAreaId="captureArea.getId()"
-                />
-                <v-alert
-                    v-else
-                    type="info"
-                    variant="tonal"
-                    prominent
-                    text="To commence capturing, you must first define at least one capture area."
-                ></v-alert>
+                <LogOutput v-if="captureAreas.length !== 0" v-for="captureArea in captureAreas" :key="captureArea.getId()"
+                    :captureAreaId="captureArea.getId()" />
+                <v-alert v-else type="info" variant="tonal" prominent
+                    text="To commence capturing, you must first define at least one capture area."></v-alert>
             </v-expansion-panels>
         </template>
     </ViewComponent>
@@ -41,11 +18,13 @@
 
 <script setup lang="ts">
 import { ref } from 'vue';
-import { useRunning, isRunning } from '@/composables/useRunning/useRunning';
 import { Vigad } from '@/proc/Vigad';
-
 import ViewComponent from '@/components/ViewComponent/ViewComponent.vue';
 import LogOutput from '@/components/LogOutput/LogOutput.vue';
+import useRunning from '@/composables/useRunning/useRunning';
+
+// Use the useRunning composable to get the isRunning state and the start/stop functions
+const { isRunning, start, stop } = useRunning();
 
 /**
  * Get singelton instance reference to vigad

--- a/src/views/CapturePage.vue
+++ b/src/views/CapturePage.vue
@@ -1,16 +1,39 @@
 <template>
     <ViewComponent title="Capturing" :loading="isRunning">
         <template v-slot:actions>
-            <v-btn v-if="!isRunning" class="rounded-pill" prepend-icon="mdi-play" variant="tonal"
-                :disabled="captureAreas.length === 0" @click="start()">Start</v-btn>
-            <v-btn v-else class="rounded-pill" prepend-icon="mdi-stop" variant="tonal" @click="stop()">Stop</v-btn>
+            <v-btn
+                v-if="!isRunning"
+                class="rounded-pill"
+                prepend-icon="mdi-play"
+                variant="tonal"
+                :disabled="captureAreas.length === 0"
+                @click="start()"
+                >Start</v-btn
+            >
+            <v-btn
+                v-else
+                class="rounded-pill"
+                prepend-icon="mdi-stop"
+                variant="tonal"
+                @click="stop()"
+                >Stop</v-btn
+            >
         </template>
         <template v-slot:default>
             <v-expansion-panels v-model="defaultOpenPanel" multiple>
-                <LogOutput v-if="captureAreas.length !== 0" v-for="captureArea in captureAreas" :key="captureArea.getId()"
-                    :captureAreaId="captureArea.getId()" />
-                <v-alert v-else type="info" variant="tonal" prominent
-                    text="To commence capturing, you must first define at least one capture area."></v-alert>
+                <LogOutput
+                    v-if="captureAreas.length !== 0"
+                    v-for="captureArea in captureAreas"
+                    :key="captureArea.getId()"
+                    :captureAreaId="captureArea.getId()"
+                />
+                <v-alert
+                    v-else
+                    type="info"
+                    variant="tonal"
+                    prominent
+                    text="To commence capturing, you must first define at least one capture area."
+                ></v-alert>
             </v-expansion-panels>
         </template>
     </ViewComponent>

--- a/src/views/RegexView.vue
+++ b/src/views/RegexView.vue
@@ -1,42 +1,23 @@
 <template>
     <ViewComponent title="Regex" :loading="false">
         <template v-slot:actions>
-            <v-btn
-                class="rounded-pill"
-                prepend-icon="mdi-plus"
-                variant="tonal"
-                @click="addCaptureArea()"
-                >Add Capture Area</v-btn
-            >
+            <v-btn class="rounded-pill" prepend-icon="mdi-plus" variant="tonal" @click="addCaptureArea()">Add Capture
+                Area</v-btn>
         </template>
         <template v-slot:default>
             <v-expansion-panels v-if="captureAreas.length !== 0" multiple>
-                <v-expansion-panel
-                    v-if="isRerendering"
-                    v-for="captureArea in captureAreas"
-                    :key="captureArea.getId()"
-                >
-                    <v-expansion-panel-title
-                        class="pa-4"
-                        expand-icon="mdi-menu-down"
-                    >
+                <v-expansion-panel v-if="isRerendering" v-for="captureArea in captureAreas" :key="captureArea.getId()">
+                    <v-expansion-panel-title class="pa-4" expand-icon="mdi-menu-down">
                         Capture area
                         {{ captureArea.getId() }}
                     </v-expansion-panel-title>
                     <v-expansion-panel-text>
-                        <CaptureAreaSearchValue
-                            :capture-area-id="captureArea.getId()"
-                        />
+                        <CaptureAreaSearchValue :capture-area-id="captureArea.getId()" />
                     </v-expansion-panel-text>
                 </v-expansion-panel>
             </v-expansion-panels>
-            <v-alert
-                v-else
-                type="info"
-                variant="tonal"
-                prominent
-                text="In order to locate a value within the stream, you must create a capture area."
-            ></v-alert>
+            <v-alert v-else type="info" variant="tonal" prominent
+                text="In order to locate a value within the stream, you must create a capture area."></v-alert>
         </template>
     </ViewComponent>
 </template>
@@ -46,12 +27,13 @@ import { ref } from 'vue';
 import ViewComponent from '@/components/ViewComponent/ViewComponent.vue';
 import CaptureAreaSearchValue from '@/components/capture-area/CaptureAreaSearchValue/CaptureAreaSearchValue.vue';
 import { Vigad } from '@/proc/Vigad';
-import {
-    isRerendering,
-    useForceRerender,
-} from '@/composables/useForceRerender/useForceRerender';
+import useForceRerender from '@/composables/useForceRerender/useForceRerender';
 import useNotificationSystem from '@/composables/useNotificationSystem/useNotificationSystem';
 
+/**
+ * Use the useForceRerender composable to get the isRerendering state and the forceRerender functions
+ */
+const { isRerendering, forceRerender } = useForceRerender();
 
 /**
  * Get singelton instance reference to vigad
@@ -68,7 +50,7 @@ const captureAreas = ref(vigad.value.getAllCaptureAreas());
  */
 async function addCaptureArea() {
     vigad.value.addCaptureArea(100, 100, 0, 0);
-    await useForceRerender();
+    await forceRerender();
     useNotificationSystem().createNotification({
         title: 'New Capture Area added'
     });

--- a/src/views/RegexView.vue
+++ b/src/views/RegexView.vue
@@ -1,23 +1,42 @@
 <template>
     <ViewComponent title="Regex" :loading="false">
         <template v-slot:actions>
-            <v-btn class="rounded-pill" prepend-icon="mdi-plus" variant="tonal" @click="addCaptureArea()">Add Capture
-                Area</v-btn>
+            <v-btn
+                class="rounded-pill"
+                prepend-icon="mdi-plus"
+                variant="tonal"
+                @click="addCaptureArea()"
+                >Add Capture Area</v-btn
+            >
         </template>
         <template v-slot:default>
             <v-expansion-panels v-if="captureAreas.length !== 0" multiple>
-                <v-expansion-panel v-if="isRerendering" v-for="captureArea in captureAreas" :key="captureArea.getId()">
-                    <v-expansion-panel-title class="pa-4" expand-icon="mdi-menu-down">
+                <v-expansion-panel
+                    v-if="isRerendering"
+                    v-for="captureArea in captureAreas"
+                    :key="captureArea.getId()"
+                >
+                    <v-expansion-panel-title
+                        class="pa-4"
+                        expand-icon="mdi-menu-down"
+                    >
                         Capture area
                         {{ captureArea.getId() }}
                     </v-expansion-panel-title>
                     <v-expansion-panel-text>
-                        <CaptureAreaSearchValue :capture-area-id="captureArea.getId()" />
+                        <CaptureAreaSearchValue
+                            :capture-area-id="captureArea.getId()"
+                        />
                     </v-expansion-panel-text>
                 </v-expansion-panel>
             </v-expansion-panels>
-            <v-alert v-else type="info" variant="tonal" prominent
-                text="In order to locate a value within the stream, you must create a capture area."></v-alert>
+            <v-alert
+                v-else
+                type="info"
+                variant="tonal"
+                prominent
+                text="In order to locate a value within the stream, you must create a capture area."
+            ></v-alert>
         </template>
     </ViewComponent>
 </template>
@@ -52,7 +71,7 @@ async function addCaptureArea() {
     vigad.value.addCaptureArea(100, 100, 0, 0);
     await forceRerender();
     useNotificationSystem().createNotification({
-        title: 'New Capture Area added'
+        title: 'New Capture Area added',
     });
 }
 </script>


### PR DESCRIPTION
# PR description
*Describe your changes in detail here*

The old composables useRunning and useForceRerender didn't really follow any composable guides and over the time as we got more composables they all followed a more structured approach, this just updates the code for better readability and use of it.

Now it is like we default export a function all the time so we have to import  the base function initially like:

// import composable
`import useTokenGenerator from '@/composables/useTokenGenerator/useTokenGenerator';`

and then we can use the base function and destructuring and get the child functions.
// import functions and variables
`const { defaultRules, generateValidToken } = useTokenGenerator();`

A different approach could be that we don't use default export, and then we instantly can destructure in the import, if you prefer this appraoch I'll have to adjust the code again.

// just as an example
`import { defaultRules, generateValidToken }  from '@/composables/useTokenGenerator/useTokenGenerator';`

Both are valid, we just should decide how we want to do it.

# Definition Of Done (DoD)
*This PR can be squashed / merged if*
- [x] a developer is assigned
- [x] the PR is NOT estimated
- [x] the PR is labeled
- [x] the PR is NOT assigned to the current sprint
- [x] a meaningful title has been set according to https://www.conventionalcommits.org/
- [x] the PR is described in detail
- [x] the PR links to an issue
- [x] the PR has been reviewed

*Add additional conditions here if necessary for this PR*

fix: #182 